### PR TITLE
Hotfix for non logged in players viewing games (HTTP 500 error)

### DIFF
--- a/app/views/games/_game_comments.html.erb
+++ b/app/views/games/_game_comments.html.erb
@@ -1,4 +1,4 @@
-<% if current_player.admin -%>
+<% if player_signed_in? && current_player.admin -%>
   <% comments = @game.comments.includes(:player)
                      .page(params[:comment_page]).per(10) -%>
 <% else -%>

--- a/app/views/landing/release_notes.html.erb
+++ b/app/views/landing/release_notes.html.erb
@@ -9,6 +9,17 @@
   <h1><%= t('landing.release_notes.title') %></h1>
 
   <div class="release-notes">
+    <!-- 1.2.3 -->
+    <div class="release">
+      <h2><span class="version">1.2.3</span>December 13th, 2018</h2>
+      <ul>
+        <li>
+          <div class="change change-fixed">fixed</div>
+          <p>Resolved an internal server exception when loading pages with comments.</p>
+        </li>
+      </ul>
+    </div>
+
     <!-- 1.2.2 -->
     <div class="release">
       <h2><span class="version">1.2.2</span>December 13th, 2018</h2>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,7 +6,7 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  version: "version 1.2.2"
+  version: "version 1.2.3"
   notification:
     game: "You placed %{position} in Game #%{game} at the %{venue}."
     comment: "@%{sender} just commented on Game #%{game} at the %{venue}."


### PR DESCRIPTION
Resolved an issue where players who aren't logged in will receive an internal server error if they attempt to access a page with comments (games).