### PR TITLE
[WIP] Add permissions and groups to control admin actions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ gem 'js-routes'
 gem 'kaminari'
 gem 'local_time'
 gem 'paperclip', '~> 6.1.0'
+gem 'pundit'
 gem 'searchkick'
 gem 'sidekiq'
 gem 'wdm', '>= 0.1.0' if Gem.win_platform?

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,8 @@ GEM
     powerpack (0.1.2)
     public_suffix (3.0.3)
     puma (3.12.0)
+    pundit (2.0.0)
+      activesupport (>= 3.0.0)
     rack (2.0.6)
     rack-protection (2.0.4)
       rack
@@ -359,6 +361,7 @@ DEPENDENCIES
   paperclip (~> 6.1.0)
   pg (~> 1.1)
   puma (~> 3.7)
+  pundit
   rails (~> 5.2.2)
   rubocop
   sass-rails (~> 5.0)

--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -16,6 +16,7 @@ class Admin::GamesController < ApplicationController
   # GET /admin/games/new
   def new
     @game = Game.new
+    authorize @game
   end
 
   # POST /admin/games

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,12 @@
 
 # Base controller
 class ApplicationController < ActionController::Base
+  include Pundit
   protect_from_forgery with: :exception
+
+  def pundit_user
+    current_player
+  end
 
   private
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Default policy
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/game_policy.rb
+++ b/app/policies/game_policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# A policy for managing access to recording games
+class GamePolicy < ApplicationPolicy
+  def new?
+    user.admin
+  end
+
+  def create?
+    user.admin
+  end
+end


### PR DESCRIPTION
This pull request introduces a new permission based system. Players are sorted into one of the following groups.

 * **Player**: No admin privileges.
 * **Tournament Director**: Limited admin privileges, such as recording games.
 * **Admin**: All admin privileges.
 * **Developer**: Limited admin privileges, but access to developer only tools like the sidekiq monitor.

This PR resolves #155